### PR TITLE
Task/feat get user neighbors method

### DIFF
--- a/Gorse.NET.Tests/GorseTest.cs
+++ b/Gorse.NET.Tests/GorseTest.cs
@@ -32,7 +32,8 @@ public class Tests
         {
             returnUser = client.GetUser("1");
             Assert.Fail();
-        } catch (GorseException e)
+        }
+        catch (GorseException e)
         {
             Assert.That(e.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
@@ -114,5 +115,19 @@ public class Tests
         });
         var items = await client.GetRecommendAsync("10");
         Assert.That(items, Is.EqualTo(new string[] { "30", "20", "10" }));
+    }
+
+    [Test]
+    public void TestUserNeighbors()
+    {
+        var users = client.GetUserNeighbors("1");
+        Assert.IsNotNull(users, "User neighbors is should not be null.");
+    }
+
+    [Test]
+    public async Task TestUserNeighborsAsync()
+    {
+        var users = await client.GetUserNeighborsAsync("1");
+        Assert.IsNotNull(users, "User neighbors is should not be null.");
     }
 }

--- a/Gorse.NET/Gorse.cs
+++ b/Gorse.NET/Gorse.cs
@@ -21,6 +21,12 @@ public class User
     }
 }
 
+public class Neighbor
+{
+    public string UserId { get; set; }
+    public double Score { get; set; }
+}
+
 public class Feedback
 {
     public string FeedbackType { set; get; } = "";
@@ -44,7 +50,7 @@ public class Result
     }
 }
 
-public class GorseException: Exception
+public class GorseException : Exception
 {
     public HttpStatusCode StatusCode { set; get; }
     public new string? Message { set; get; }
@@ -110,7 +116,17 @@ public class Gorse
         return RequestAsync<string[], Object>(Method.Get, "api/recommend/" + userId, null);
     }
 
-    public RetType Request<RetType, ReqType>(Method method, string resource, ReqType? req) where ReqType: class
+    public List<Neighbor> GetUserNeighbors(string userId)
+    {
+        return Request<List<Neighbor>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
+    }
+
+    public Task<List<Neighbor>> GetUserNeighborsAsync(string userId)
+    {
+        return RequestAsync<List<Neighbor>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
+    }
+
+    public RetType Request<RetType, ReqType>(Method method, string resource, ReqType? req) where ReqType : class
     {
         var request = new RestRequest(resource, method);
         if (req != null)
@@ -125,7 +141,8 @@ public class Gorse
                 StatusCode = response.StatusCode,
                 Message = response.Content
             };
-        } else if (response.Content == null)
+        }
+        else if (response.Content == null)
         {
             throw new GorseException
             {

--- a/Gorse.NET/Gorse.cs
+++ b/Gorse.NET/Gorse.cs
@@ -21,9 +21,9 @@ public class User
     }
 }
 
-public class Neighbor
+public class UserScore
 {
-    public string UserId { get; set; }
+    public string UserId { get; set; } = "";
     public double Score { get; set; }
 }
 
@@ -116,14 +116,14 @@ public class Gorse
         return RequestAsync<string[], Object>(Method.Get, "api/recommend/" + userId, null);
     }
 
-    public List<Neighbor> GetUserNeighbors(string userId)
+    public List<UserScore> GetUserNeighbors(string userId)
     {
-        return Request<List<Neighbor>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
+        return Request<List<UserScore>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
     }
 
-    public Task<List<Neighbor>> GetUserNeighborsAsync(string userId)
+    public Task<List<UserScore>> GetUserNeighborsAsync(string userId)
     {
-        return RequestAsync<List<Neighbor>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
+        return RequestAsync<List<UserScore>, Object>(Method.Get, @"api/user/{userId}/neighbors", null);
     }
 
     public RetType Request<RetType, ReqType>(Method method, string resource, ReqType? req) where ReqType : class


### PR DESCRIPTION
Hello @zhenghaoz,

I've noticed Gorse.NET is missing a method for retrieving similar users, like the API endpoint api/user/{user}/neighbors?n=10. To address this, I've submitted a pull request to add this feature and help make the library more complete.

Additionally, I've renamed the class UserScore to Neighbor instead of Score, as suggested earlier on the previous pull request, to avoid confusion with the Score field in the class. I’ve also refactored the code for better readability by adding proper spacing between methods.

Looking forward to your feedback!