### PR TITLE
Task/fix null response error

### DIFF
--- a/Gorse.NET.Tests/GorseTest.cs
+++ b/Gorse.NET.Tests/GorseTest.cs
@@ -104,6 +104,13 @@ public class Tests
     }
 
     [Test]
+    public void TestRecommend_Returns_Null()
+    {
+        var items = client.GetRecommend("40");
+        Assert.IsNull(items);
+    }
+
+    [Test]
     public async Task TestRecommendAsync()
     {
         var db = redis.GetDatabase();
@@ -115,6 +122,14 @@ public class Tests
         });
         var items = await client.GetRecommendAsync("10");
         Assert.That(items, Is.EqualTo(new string[] { "30", "20", "10" }));
+    }
+
+    [Test]
+    public async Task TestRecommendAsync_Returns_Null()
+    {
+
+        var items = await client.GetRecommendAsync("40");
+        Assert.IsNull(items);
     }
 
     [Test]


### PR DESCRIPTION
Handles cases where the Gorse server returns a null response for GetRecommend(string userId) by returning null instead of throwing an exception, allowing users to manage null responses more flexibly. Additionally, adds a constructor to the GorseException class to pass the error message to the base Exception class, ensuring the error is displayed. Previously, GorseException lacked a constructor to initialize the base message.

Additionally, replace the status code check with a more robust check.

`// Checks only for HTTP 200
 if (response.StatusCode != HttpStatusCode.OK)`
 
        
`// Checks succes
if (!response.IsSuccessStatusCode)
{
    throw new GorseException
    {
        StatusCode = response.StatusCode,
        Message = response.Content
    };`




