### PR TITLE
bug: fix incorrect UserScore model field

### DIFF
--- a/Gorse.NET/Gorse.cs
+++ b/Gorse.NET/Gorse.cs
@@ -23,7 +23,7 @@ public class User
 
 public class UserScore
 {
-    public string UserId { get; set; } = "";
+    public string Id { get; set; } = "";
     public double Score { get; set; }
 }
 


### PR DESCRIPTION
This pull request fixes a bug in the `UserScore` model where the user identifier field was incorrectly named `UserId `instead of the expected `Id`. This correction aligns the model with the expected JSON data from the Gorse recommender system.