### PR TITLE
feat: add SearchItems API

### DIFF
--- a/Gorse.NET.Tests/UnitTests/TestItemsAPI.cs
+++ b/Gorse.NET.Tests/UnitTests/TestItemsAPI.cs
@@ -8,6 +8,10 @@ public partial class Tests
     [Test]
     public void TestItems()
     {
+        var searchResult = client.SearchItems("Toy Story", 3);
+        Assert.That(searchResult.Items, Is.Not.Empty);
+        Assert.That(searchResult.Items[0].Comment, Is.EqualTo("Toy Story (1995)"));
+
         var item = new Item
         {
             ItemId = "2000",
@@ -45,6 +49,10 @@ public partial class Tests
     [Test]
     public async Task TestItemsAsync()
     {
+        var searchResult = await client.SearchItemsAsync("Toy Story", 3);
+        Assert.That(searchResult.Items, Is.Not.Empty);
+        Assert.That(searchResult.Items[0].Comment, Is.EqualTo("Toy Story (1995)"));
+
         var item = new Item
         {
             ItemId = "2000",

--- a/Gorse.NET/API/ItemsAPI.cs
+++ b/Gorse.NET/API/ItemsAPI.cs
@@ -45,6 +45,16 @@ public partial class Gorse
         return _client.RequestAsync<ItemsResponse, Object>(Method.Get, $"api/items?n={n}&cursor={cursor}", null)!;
     }
 
+    public ItemsResponse SearchItems(string query, int n)
+    {
+        return _client.Request<ItemsResponse, Object>(Method.Get, $"api/items?q={Uri.EscapeDataString(query)}&n={n}", null)!;
+    }
+
+    public Task<ItemsResponse> SearchItemsAsync(string query, int n)
+    {
+        return _client.RequestAsync<ItemsResponse, Object>(Method.Get, $"api/items?q={Uri.EscapeDataString(query)}&n={n}", null)!;
+    }
+
     public Result DeleteItem(string itemId)
     {
         return _client.Request<Result, Object>(Method.Delete, "api/item/" + itemId, null)!;


### PR DESCRIPTION
## Summary
- Adds synchronous and asynchronous `SearchItems` methods returning `ItemsResponse`.
- Call `GET /api/items?q=<query>&n=<n>` following gorse-io/gorse-go#16
- Add item-search integration coverage

## Test Plan
- `docker run ... dotnet test --no-restore --filter 'FullyQualifiedName~TestItems'`
