### PR TITLE
feat: support recommendation parameters

### DIFF
--- a/Gorse.NET.Tests/UnitTests/TestRecommendationAPI.cs
+++ b/Gorse.NET.Tests/UnitTests/TestRecommendationAPI.cs
@@ -8,9 +8,18 @@ public partial class Tests
     public void TestRecommend()
     {
         client.InsertUser(new Models.User { UserId = "3000" });
-        var recommendations = client.GetRecommend(
-            "3000", ["Drama", "Comedy"], "recommend", "1h", 3, 0);
+        var recommendations = client.GetRecommend("3000");
         Assert.That(recommendations, Is.Not.Null);
+        Assert.That(recommendations[0].Id, Is.EqualTo("315"));
+        Assert.That(recommendations[1].Id, Is.EqualTo("1432"));
+        Assert.That(recommendations[2].Id, Is.EqualTo("918"));
+    }
+
+    [Test]
+    public void TestRecommendMultipleCategories()
+    {
+        client.InsertUser(new Models.User { UserId = "5000" });
+        var recommendations = client.GetRecommend("5000", categories: ["Drama", "Comedy"], n: 3);
         Assert.That(recommendations, Has.Count.EqualTo(3));
         foreach (var recommendation in recommendations)
         {
@@ -23,9 +32,18 @@ public partial class Tests
     public async Task TestRecommendAsync()
     {
         await client.InsertUserAsync(new User { UserId = "4000" });
-        var recommendations = await client.GetRecommendAsync(
-            "4000", ["Drama", "Comedy"], "recommend", "1h", 3, 0);
+        var recommendations = await client.GetRecommendAsync("4000");
         Assert.That(recommendations, Is.Not.Null);
+        Assert.That(recommendations[0].Id, Is.EqualTo("315"));
+        Assert.That(recommendations[1].Id, Is.EqualTo("1432"));
+        Assert.That(recommendations[2].Id, Is.EqualTo("918"));
+    }
+
+    [Test]
+    public async Task TestRecommendMultipleCategoriesAsync()
+    {
+        await client.InsertUserAsync(new User { UserId = "6000" });
+        var recommendations = await client.GetRecommendAsync("6000", categories: ["Drama", "Comedy"], n: 3);
         Assert.That(recommendations, Has.Count.EqualTo(3));
         foreach (var recommendation in recommendations)
         {

--- a/Gorse.NET.Tests/UnitTests/TestRecommendationAPI.cs
+++ b/Gorse.NET.Tests/UnitTests/TestRecommendationAPI.cs
@@ -8,21 +8,29 @@ public partial class Tests
     public void TestRecommend()
     {
         client.InsertUser(new Models.User { UserId = "3000" });
-        var recommendations = client.GetRecommend("3000");
+        var recommendations = client.GetRecommend(
+            "3000", ["Drama", "Comedy"], "recommend", "1h", 3, 0);
         Assert.That(recommendations, Is.Not.Null);
-        Assert.That(recommendations[0].Id, Is.EqualTo("315"));
-        Assert.That(recommendations[1].Id, Is.EqualTo("1432"));
-        Assert.That(recommendations[2].Id, Is.EqualTo("918"));
+        Assert.That(recommendations, Has.Count.EqualTo(3));
+        foreach (var recommendation in recommendations)
+        {
+            var item = client.GetItem(recommendation.Id);
+            Assert.That(item.Categories, Has.Some.Matches<string>(category => category is "Drama" or "Comedy"));
+        }
     }
 
     [Test]
     public async Task TestRecommendAsync()
     {
         await client.InsertUserAsync(new User { UserId = "4000" });
-        var recommendations = await client.GetRecommendAsync("4000");
+        var recommendations = await client.GetRecommendAsync(
+            "4000", ["Drama", "Comedy"], "recommend", "1h", 3, 0);
         Assert.That(recommendations, Is.Not.Null);
-        Assert.That(recommendations[0].Id, Is.EqualTo("315"));
-        Assert.That(recommendations[1].Id, Is.EqualTo("1432"));
-        Assert.That(recommendations[2].Id, Is.EqualTo("918"));
+        Assert.That(recommendations, Has.Count.EqualTo(3));
+        foreach (var recommendation in recommendations)
+        {
+            var item = await client.GetItemAsync(recommendation.Id);
+            Assert.That(item.Categories, Has.Some.Matches<string>(category => category is "Drama" or "Comedy"));
+        }
     }
 }

--- a/Gorse.NET/API/RecommendationAPI.cs
+++ b/Gorse.NET/API/RecommendationAPI.cs
@@ -11,7 +11,16 @@ public partial class Gorse
     /// </summary>
     public List<UserScore>? GetRecommend(string userId)
     {
-        return _client.RequestWithHeaders<List<UserScore>, Object>(Method.Get, "api/recommend/" + userId, null, 
+        return _client.RequestWithHeaders<List<UserScore>, Object>(Method.Get,
+            "api/recommend/" + Uri.EscapeDataString(userId), null,
+            new Dictionary<string, string> { { "X-API-Version", "2" } });
+    }
+
+    public List<UserScore>? GetRecommend(string userId, IEnumerable<string>? categories,
+        string? writeBackType, string? writeBackDelay, int? n, int? offset)
+    {
+        return _client.RequestWithHeaders<List<UserScore>, Object>(Method.Get,
+            GetRecommendResource(userId, categories, writeBackType, writeBackDelay, n, offset), null,
             new Dictionary<string, string> { { "X-API-Version", "2" } });
     }
 
@@ -21,8 +30,48 @@ public partial class Gorse
     /// </summary>
     public Task<List<UserScore>?> GetRecommendAsync(string userId)
     {
-        return _client.RequestWithHeadersAsync<List<UserScore>, Object>(Method.Get, "api/recommend/" + userId, null,
+        return _client.RequestWithHeadersAsync<List<UserScore>, Object>(Method.Get,
+            "api/recommend/" + Uri.EscapeDataString(userId), null,
             new Dictionary<string, string> { { "X-API-Version", "2" } });
+    }
+
+    public Task<List<UserScore>?> GetRecommendAsync(string userId, IEnumerable<string>? categories,
+        string? writeBackType, string? writeBackDelay, int? n, int? offset)
+    {
+        return _client.RequestWithHeadersAsync<List<UserScore>, Object>(Method.Get,
+            GetRecommendResource(userId, categories, writeBackType, writeBackDelay, n, offset), null,
+            new Dictionary<string, string> { { "X-API-Version", "2" } });
+    }
+
+    private static string GetRecommendResource(string userId, IEnumerable<string>? categories,
+        string? writeBackType, string? writeBackDelay, int? n, int? offset)
+    {
+        var query = new List<string>();
+        if (categories != null)
+        {
+            query.AddRange(categories
+                .Where(category => !string.IsNullOrEmpty(category))
+                .Select(category => "category=" + Uri.EscapeDataString(category)));
+        }
+        if (!string.IsNullOrEmpty(writeBackType))
+        {
+            query.Add("write-back-type=" + Uri.EscapeDataString(writeBackType));
+        }
+        if (!string.IsNullOrEmpty(writeBackDelay))
+        {
+            query.Add("write-back-delay=" + Uri.EscapeDataString(writeBackDelay));
+        }
+        if (n.HasValue)
+        {
+            query.Add("n=" + n.Value);
+        }
+        if (offset.HasValue)
+        {
+            query.Add("offset=" + offset.Value);
+        }
+
+        var resource = "api/recommend/" + Uri.EscapeDataString(userId);
+        return query.Count > 0 ? resource + "?" + string.Join("&", query) : resource;
     }
 
     public List<UserScore> GetUserNeighbors(string userId, int n = 100, int offset = 0)

--- a/Gorse.NET/API/RecommendationAPI.cs
+++ b/Gorse.NET/API/RecommendationAPI.cs
@@ -9,15 +9,8 @@ public partial class Gorse
     /// Get recommendation with scores for a user.
     /// Uses X-API-Version: 2 header to return scores.
     /// </summary>
-    public List<UserScore>? GetRecommend(string userId)
-    {
-        return _client.RequestWithHeaders<List<UserScore>, Object>(Method.Get,
-            "api/recommend/" + Uri.EscapeDataString(userId), null,
-            new Dictionary<string, string> { { "X-API-Version", "2" } });
-    }
-
-    public List<UserScore>? GetRecommend(string userId, IEnumerable<string>? categories,
-        string? writeBackType, string? writeBackDelay, int? n, int? offset)
+    public List<UserScore>? GetRecommend(string userId, IEnumerable<string>? categories = null,
+        string? writeBackType = null, string? writeBackDelay = null, int? n = null, int? offset = null)
     {
         return _client.RequestWithHeaders<List<UserScore>, Object>(Method.Get,
             GetRecommendResource(userId, categories, writeBackType, writeBackDelay, n, offset), null,
@@ -28,15 +21,8 @@ public partial class Gorse
     /// Get recommendation with scores for a user asynchronously.
     /// Uses X-API-Version: 2 header to return scores.
     /// </summary>
-    public Task<List<UserScore>?> GetRecommendAsync(string userId)
-    {
-        return _client.RequestWithHeadersAsync<List<UserScore>, Object>(Method.Get,
-            "api/recommend/" + Uri.EscapeDataString(userId), null,
-            new Dictionary<string, string> { { "X-API-Version", "2" } });
-    }
-
-    public Task<List<UserScore>?> GetRecommendAsync(string userId, IEnumerable<string>? categories,
-        string? writeBackType, string? writeBackDelay, int? n, int? offset)
+    public Task<List<UserScore>?> GetRecommendAsync(string userId, IEnumerable<string>? categories = null,
+        string? writeBackType = null, string? writeBackDelay = null, int? n = null, int? offset = null)
     {
         return _client.RequestWithHeadersAsync<List<UserScore>, Object>(Method.Get,
             GetRecommendResource(userId, categories, writeBackType, writeBackDelay, n, offset), null,


### PR DESCRIPTION
## Summary
- preserve the existing sync and async single-argument overloads
- add sync and async overloads for categories, write-back, `n`, and `offset`
- encode multiple categories as repeated query parameters on the current endpoint
- keep scored responses with `X-API-Version: 2`

## Tests
- `dotnet test Gorse.NET.Tests/Gorse.NET.Tests.csproj`
- `dotnet build Gorse.NET.Tests/Gorse.NET.Tests.csproj`
